### PR TITLE
Fix /usr/libexec/cydia/firmware.sh not finishing and iOS 9 compat

### DIFF
--- a/src/Tweak.xmi
+++ b/src/Tweak.xmi
@@ -96,6 +96,11 @@ static void traceURISchemes() {
 
     // Only hook Apps the user has selected in Introspy's settings panel
     NSString *appId = [[NSBundle mainBundle] bundleIdentifier];
+    if (appId == nil) {
+        appId = [[NSProcessInfo processInfo] processName];
+        NSLog(@"Introspy - Process has no bundle ID, use process name instead: %@", appId);
+    }
+    
     // Load Introspy preferences
     NSMutableDictionary *preferences = [[NSMutableDictionary alloc] initWithContentsOfFile:preferenceFilePath];
     id shouldHook = [preferences objectForKey:appId];

--- a/src/introspy.plist
+++ b/src/introspy.plist
@@ -1,0 +1,1 @@
+{ Filter = { Bundles = ( "com.apple.Foundation" ); }; }


### PR DESCRIPTION
Details:
The new firmware.sh version will retry `gssc` process until it doesn't return a string in both stderr and stdout that contains `(null)`. Since Introspy hooks into all processes, Introspy is injected into `gssc`, it doesn't find a bundle ID and thus prints `(null)` in the logs and causing firmware.sh to keep retrying forever using battery and blocking firmware.sh's completion.

Fixed this by getting the process name instead if the bundle ID is not found. I understand this is a problem in firmware.sh also and will occur with other tweaks that print `(null)` into the logs and that should be fixed, too.
